### PR TITLE
Aoc2024day05dictrules

### DIFF
--- a/advent-of-code/2024/day05/prog1.py
+++ b/advent-of-code/2024/day05/prog1.py
@@ -5,7 +5,7 @@ def main():
     print_results(ok_pages)
 
 
-type TypeRules = list[tuple[int, int]]
+type TypeRules = dict[int, set[int]]
 
 
 def find_ok_pages(rules: TypeRules, list_pages: list[list[int]]) -> list[list[int]]:
@@ -17,15 +17,14 @@ def check_page(pages: list[int], rules: TypeRules) -> bool:
         for j, page_right in enumerate(pages):
             if i >= j:
                 continue
-            for rule in rules:
-                if rule == (page_right, page_left):
-                    return False
+            if page_right in rules.get(page_left, {}):
+                return False
     return True
 
 
 def read_rules() -> TypeRules:
     finished = False
-    res = []
+    res = {}
     while not finished:
         try:
             line = input()
@@ -34,7 +33,10 @@ def read_rules() -> TypeRules:
         if line == "":
             finished = True
         else:
-            res.append(tuple(map(int, line.split("|"))))
+            x, y = tuple(map(int, line.split("|")))
+            if y not in res:
+                res[y] = set()
+            res[y].add(x)
     return res
 
 

--- a/advent-of-code/2024/day05/prog2.py
+++ b/advent-of-code/2024/day05/prog2.py
@@ -5,7 +5,7 @@ def main():
     print_results(ok_pages)
 
 
-type TypeRules = list[tuple[int, int]]
+type TypeRules = dict[int, set[int]]
 
 
 def find_ok_pages(rules: TypeRules, list_pages: list[list[int]]) -> list[list[int]]:
@@ -18,13 +18,10 @@ def check_page(pages: list[int], rules: TypeRules) -> bool:
         for j, page_right in enumerate(pages):
             if i >= j:
                 continue
-            for rule in rules:
-                if rule == (page_right, page_left):
-                    # page j is smaller than page i, so it must
-                    # be lower than other pages between i and j (i<j)
-                    rotate_pages(pages, i, j)
-                    page_left = page_right  # For the next iteration
-                    sorted = True
+            if page_right in rules.get(page_left, {}):
+                rotate_pages(pages, i, j)
+                page_left = page_right  # For the next iteration
+                sorted = True
     return sorted
 
 
@@ -37,7 +34,7 @@ def rotate_pages(pages: list[int], i: int, j: int) -> None:
 
 def read_rules() -> TypeRules:
     finished = False
-    res = []
+    res = {}
     while not finished:
         try:
             line = input()
@@ -46,7 +43,10 @@ def read_rules() -> TypeRules:
         if line == "":
             finished = True
         else:
-            res.append(tuple(map(int, line.split("|"))))
+            x, y = tuple(map(int, line.split("|")))
+            if y not in res:
+                res[y] = set()
+            res[y].add(x)
     return res
 
 


### PR DESCRIPTION
Just a bit faster rule-checker.

0.02s vs 0.64 (part2).

```
17:14:59  ...advent-of-code/2024/day05   aoc2024day05dictrules ✘ ✭ 
$ time uv run python prog2.py < my.in
Result: 4145
uv run python prog2.py < my.in  0.02s user 0.03s system 43% cpu 0.105 total

 17:15:24  ...advent-of-code/2024/day05   aoc2024day05dictrules ✘ ✭ 
$ time uv run python prog1.py < my.in
Result: 6949
uv run python prog1.py < my.in  0.02s user 0.01s system 95% cpu 0.038 total

 17:15:29  ...advent-of-code/2024/day05   aoc2024day05dictrules ✘ ✭ 
$ git switch master
Switched to branch 'master'
Your branch is up to date with 'origin/master'.

 17:15:35  ...advent-of-code/2024/day05   master ✘ ✭ 
$ time uv run python prog2.py < my.in
Result: 4145
uv run python prog2.py < my.in  0.64s user 0.01s system 99% cpu 0.656 total

 17:15:38  ...advent-of-code/2024/day05   master ✘ ✭ 
$ time uv run python prog1.py < my.in
Result: 6949
uv run python prog1.py < my.in  0.46s user 0.01s system 99% cpu 0.470 total

```